### PR TITLE
Fix to stop deque mutation error spam in the GUI

### DIFF
--- a/rqt_robot_monitor/src/rqt_robot_monitor/timeline.py
+++ b/rqt_robot_monitor/src/rqt_robot_monitor/timeline.py
@@ -155,5 +155,5 @@ class Timeline(QObject):
         return len(self._queue)
 
     def __iter__(self):
-        for msg in self._queue:
+        for msg in list(self._queue):
             yield msg


### PR DESCRIPTION
The error:

Traceback (most recent call last):
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rqt_robot_monitor/timeline_view.py", line 194, in _slot_redraw
for i, m in enumerate(self._timeline):
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rqt_robot_monitor/timeline.py", line 158, in __iter__
    for msg in self._queue:
RuntimeError: deque mutated during iteration

@abencz 
